### PR TITLE
Додає scale на swiper-btn

### DIFF
--- a/src/css/swiper.css
+++ b/src/css/swiper.css
@@ -22,12 +22,22 @@
 .right-icon {
     cursor: pointer;
     stroke: rgba(255, 255, 255, 0.5);
-    transition: stroke 300ms cubic-bezier(0.075, 0.82, 0.165, 1);
+		transform: scale(1.0);
+    transition: stroke 300ms cubic-bezier(0.075, 0.82, 0.165, 1),
+			transform 300ms cubic-bezier(0.075, 0.82, 0.165, 1);
 }
 
 .left-icon:is(:hover, :focus),
 .right-icon:is(:hover, :focus) {
     stroke: var(--white-color);
+		
+}
+
+.left-icon:hover,
+.left-icon:focus,
+.right-icon:hover,
+.right-icon:focus {
+	transform: scale(1.1);
 }
 
 .swiper-pagination {


### PR DESCRIPTION
Додає scale на swiper-btn.
Примітка, був варіант додатиу вже існуючі класи, але додав окремим стилями, що на DESKTOP при ховері скейл не фіксувався, а працював і в зворотню сторону:

.left-icon:hover,
.left-icon:focus,
.right-icon:hover,
.right-icon:focus {
	transform: scale(1.1);
}